### PR TITLE
Send floats

### DIFF
--- a/components/ValueToFloat.hpp
+++ b/components/ValueToFloat.hpp
@@ -1,0 +1,21 @@
+/* microflo_component yaml
+name: ValueToFloat
+description: "Convert integer input to float, dividing to 1000"
+inports:
+  in:
+    type: integer
+    description: ""
+outports:
+  out:
+    type: number
+    description: ""
+microflo_component */
+class ValueToFloat : public SingleOutputComponent {
+public:
+    virtual void process(Packet in, MicroFlo::PortId port) {
+      using namespace ValueToFloatPorts;
+      if (port == InPorts::in) {
+        send(in.asInteger() / 1000.0, OutPorts::out);
+      }
+    }
+};

--- a/components/ValueToFloat.hpp
+++ b/components/ValueToFloat.hpp
@@ -15,7 +15,8 @@ public:
     virtual void process(Packet in, MicroFlo::PortId port) {
       using namespace ValueToFloatPorts;
       if (port == InPorts::in) {
-        send(in.asInteger() / 1000.0, OutPorts::out);
+        const float val = in.asInteger() / 1000.0;
+        send(val, OutPorts::out);
       }
     }
 };

--- a/graphs/main.fbp
+++ b/graphs/main.fbp
@@ -11,11 +11,11 @@ INPORT=sendTimer.INTERVAL:SENDINTERVAL
 sampleTimer -> triggerSample(Split) OUT1 -> dht(ReadDHT22)
 triggerSample OUT2 -> sds(ReadSDS11)
 
-dht TEMPERATURE -> filterTemp(RunningMedian) -> DATA latestTemp(HoldPacket)
-dht HUMIDITY -> filterHumidity(RunningMedian) -> DATA latestHumidity(HoldPacket)
+dht TEMPERATURE -> filterTemp(RunningMedian) -> (ValueToFloat) -> DATA latestTemp(HoldPacket)
+dht HUMIDITY -> filterHumidity(RunningMedian) -> (ValueToFloat) -> DATA latestHumidity(HoldPacket)
 
-sds PM25 -> filterFine(RunningMedian) -> DATA latestFine(HoldPacket)
-sds PM10 -> filterCoarse(RunningMedian) -> DATA latestCoarse(HoldPacket)
+sds PM25 -> filterFine(RunningMedian) -> (ValueToFloat) -> DATA latestFine(HoldPacket)
+sds PM10 -> filterCoarse(RunningMedian) -> (ValueToFloat) -> DATA latestCoarse(HoldPacket)
 
 '10000' -> INTERVAL sendTimer(Timer) -> sendSplit(Split)
 sendSplit OUT1 -> latestTemp

--- a/spec/ValueToFloat.yaml
+++ b/spec/ValueToFloat.yaml
@@ -1,0 +1,10 @@
+topic: ValueToFloat
+cases:
+-
+  name: 'when receiving an integer'
+  assertion: 'should divide and send as float'
+  inputs:
+    in: 2500
+  expect:
+    out:
+      equals: 2.5

--- a/spec/ValueToFloat.yaml
+++ b/spec/ValueToFloat.yaml
@@ -1,7 +1,15 @@
 topic: ValueToFloat
 cases:
 -
-  name: 'when receiving an integer'
+  name: 'when receiving 10000'
+  assertion: 'should divide and send as float'
+  inputs:
+    in: 10000
+  expect:
+    out:
+      equals: 10.0
+-
+  name: 'when receiving 2500'
   assertion: 'should divide and send as float'
   inputs:
     in: 2500


### PR DESCRIPTION
We have to use integer values for RunningMedian to work. But values should be converted back to floats before sending out.